### PR TITLE
Fix discontinued brew cask command

### DIFF
--- a/laptop.local
+++ b/laptop.local
@@ -27,7 +27,7 @@ if [ ! -f ~/.git-prompt.sh ]; then
 fi
 
 fancy_echo "Installing aptible ..."
-brew cask install aptible
+brew install --cask aptible
 
 fancy_echo "Installing kubectl"
 brew install kubectl


### PR DESCRIPTION
The `brew cask install` command has been discontinued: https://github.com/Homebrew/discussions/discussions/340 .
Replaced by `brew install --cask` instead. Updating the setup script to reflect this change.